### PR TITLE
Fixed link to canvasXpress.min.js in blast_results page. Fixes #4

### DIFF
--- a/src/queue/server/tpl/blast_results.tpl
+++ b/src/queue/server/tpl/blast_results.tpl
@@ -1,7 +1,6 @@
 {#block name="head"#}
 
-    <!--[if lt IE 9]><script type="text/javascript" src="http://canvasxpress.org/js/flashcanvas.js"></script><![endif]-->
-    <script type="text/javascript" src="http://canvasxpress.org/js/canvasxpress/canvasxpress/js/canvasXpress.min.js"></script>
+    <script type="text/javascript" src="{#$AppPath#}/js/canvasxpress/canvasxpress/js/canvasXpress.min.js"></script>
     <!-- use chrome frame if installed and user is using IE -->
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <script type="text/javascript" src="{#$path_prefix#}js/blast_results.js"></script>


### PR DESCRIPTION
The link to the canvasXpress.min.js was corrected to use the local version from the git submodule.
It fixes #4 
